### PR TITLE
Prevent XXE injection when parsing XML

### DIFF
--- a/play-ws-standalone-xml/src/main/scala/play/api/libs/ws/XMLBodyReadables.scala
+++ b/play-ws-standalone-xml/src/main/scala/play/api/libs/ws/XMLBodyReadables.scala
@@ -25,7 +25,7 @@ trait XMLBodyReadables {
    * }}}
    */
   implicit val readableAsXml: BodyReadable[Elem] = BodyReadable { response =>
-    xml.XML.load(new InputSource(new ByteArrayInputStream(response.bodyAsBytes.toArray)))
+    XML.parser.load(new InputSource(new ByteArrayInputStream(response.bodyAsBytes.toArray)))
   }
 
 }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [X] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #488

## Purpose

WS API `response.xml` is vulnerable to XXE injection attacks. Tracing the issue it seems to have been introduced a few years ago when the custom XML parser was replaced by a default one without the `xercesSaxParserFactory`.

I have reverted the code to using the custom factory parser.